### PR TITLE
Upgrade CLI to v0.40.0 to support GCP Identity Provider

### DIFF
--- a/env-export/Dockerfile
+++ b/env-export/Dockerfile
@@ -1,4 +1,4 @@
-FROM secrethub/cli:0.38.0
+FROM secrethub/cli:0.40.0
 
 RUN apk add sed
 


### PR DESCRIPTION
This makes it possible for GitHub Actions runners on Google Compute Engine to load secrets without needing to set `SECRETHUB_CREDENTIAL`.