### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -8,8 +8,15 @@ jobs:
     name: Bump app info version
     runs-on: ubuntu-latest
     steps:
+      - name: Load secrets
+        uses: secrethub/actions/env-export@v0.1.0
+        env:
+          SECRETHUB_CREDENTIAL: ${{ secrets.SECRETHUB_CREDENTIAL }}
+          GITHUB_TOKEN: secrethub://secrethub/github-actions/github/token
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
       - name: Bump version
         uses: florisvdg/action-version-bump@v0.1.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: ./env-export
         env:
           SECRETHUB_CREDENTIAL: ${{ secrets.SECRETHUB_CREDENTIAL }}
-          SECRET: secrethub://secrethub/tst-github-action/secret
+          SECRET: secrethub://secrethub/github-actions/tst/secret
       - name: Print environment with masked secrets
         run: printenv
       - name: Test secret is set to correct value

--- a/env-export/app-info.sh
+++ b/env-export/app-info.sh
@@ -2,4 +2,4 @@
 
 export SECRETHUB_APP_INFO_NAME=secrethub-action-env-export
 # Version is automatically bumped on release branches
-export SECRETHUB_APP_INFO_VERSION=0.1.0
+export SECRETHUB_APP_INFO_VERSION=0.2.0


### PR DESCRIPTION
### Added

* Support for the GCP Identity Provider: GitHub Actions runners on Google Compute Engine can now load secrets without needing to set `SECRETHUB_CREDENTIAL`. (#14)
