### PR TITLE
Use environment files for supported runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,14 @@ jobs:
         env:
           SECRETHUB_CREDENTIAL: ${{ secrets.SECRETHUB_CREDENTIAL }}
           SECRET: secrethub://secrethub/github-actions/tst/secret
+          MULTILINE_SECRET: secrethub://secrethub/github-actions/tst/multiline_secret
       - name: Print environment with masked secrets
         run: printenv
       - name: Test secret is set to correct value
-        run: if [ $SECRET != "DDXLKkBhprQgW7w7OFsM8y" ]; then echo "secret is not set as expected" && exit 1; fi
+        run: if [ "$SECRET" != "DDXLKkBhprQgW7w7OFsM8y" ]; then echo "secret is not set as expected" && exit 1; fi
+      - name: Test multiline secret is set to correct value
+        env:
+          MULTILINE_SECRET_EXPECTED: |-
+            4dAXbmYWiLkyYpExLnhGRD9wA7
+            rsrNbNYprQZHz8Vtgu4fJezGDB
+        run: if [ "$MULTILINE_SECRET" != "$MULTILINE_SECRET_EXPECTED" ]; then echo "secret is not set as expected" && exit 1; fi


### PR DESCRIPTION
The old `::set-env` syntax is deprecated because of [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w). A new method of setting environment variables using a file was introduced to solve this issue.

The SecretHub Action now checks if the runner supports this new method and uses if it is available. A random heredoc identifier is used to make sure that it is practically impossible that there is a collision between the identifier and the content of the secret (even if the content is controlled by an untrusted source).

More information about the new syntax can be found here: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#multline-strings

**Many thanks to @cxhercules for [reporting](https://github.com/secrethub/actions/pull/18) this issue and providing a suggested fix!**