### PR TITLE
Use environment files for supported runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,14 @@ jobs:
         env:
           SECRETHUB_CREDENTIAL: ${{ secrets.SECRETHUB_CREDENTIAL }}
           SECRET: secrethub://secrethub/github-actions/tst/secret
+          MULTILINE_SECRET: secrethub://secrethub/github-actions/tst/multiline_secret
       - name: Print environment with masked secrets
         run: printenv
       - name: Test secret is set to correct value
-        run: if [ $SECRET != "DDXLKkBhprQgW7w7OFsM8y" ]; then echo "secret is not set as expected" && exit 1; fi
+        run: if [ "$SECRET" != "DDXLKkBhprQgW7w7OFsM8y" ]; then echo "secret is not set as expected" && exit 1; fi
+      - name: Test multiline secret is set to correct value
+        env:
+          MULTILINE_SECRET_EXPECTED: |-
+            4dAXbmYWiLkyYpExLnhGRD9wA7
+            rsrNbNYprQZHz8Vtgu4fJezGDB
+        run: if [ "$MULTILINE_SECRET" != "$MULTILINE_SECRET_EXPECTED" ]; then echo "secret is not set as expected" && exit 1; fi

--- a/env-export/entrypoint.sh
+++ b/env-export/entrypoint.sh
@@ -20,5 +20,5 @@ for var_name in $env_var_names; do
 
 	# Escape percent signs and newlines when setting the environment variable
 	escaped_env_var_value=$(echo -n "$secret_value" | sed -z -e 's/%/%25/g' -e 's/\n/%0A/g')
-	echo "::set-env name=$var_name::$escaped_env_var_value"
+	echo "$var_name=$escaped_env_var_value" >> $GITHUB_ENV
 done

--- a/env-export/entrypoint.sh
+++ b/env-export/entrypoint.sh
@@ -18,7 +18,18 @@ for var_name in $env_var_names; do
 	done
 	unset IFS
 
-	# Escape percent signs and newlines when setting the environment variable
-	escaped_env_var_value=$(echo -n "$secret_value" | sed -z -e 's/%/%25/g' -e 's/\n/%0A/g')
-	echo "$var_name=$escaped_env_var_value" >> $GITHUB_ENV
+	# Use new environment file syntax on runners that support it.
+	if [ -n "${GITHUB_ENV}" ]; then
+		# A random 64 character string is used as the heredoc identifier, to make it practically
+		# impossible that this string appears in the secret.
+		random_heredoc_identifier=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n1)
+		
+		echo "$var_name<<${random_heredoc_identifier}" >> $GITHUB_ENV
+		echo "$secret_value" >> $GITHUB_ENV
+		echo "${random_heredoc_identifier}" >> $GITHUB_ENV
+	else
+		# Escape percent signs and newlines when setting the environment variable
+		escaped_env_var_value=$(echo -n "$secret_value" | sed -z -e 's/%/%25/g' -e 's/\n/%0A/g')
+		echo "::set-env name=$var_name::$escaped_env_var_value"
+	fi
 done


### PR DESCRIPTION
The old `::set-env` syntax is deprecated because of [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w). A new method of setting environment variables using a file was introduced to solve this issue.

The SecretHub Action now checks if the runner supports this new method and uses if it is available. A random heredoc identifier is used to make sure that it is practically impossible that there is a collision between the identifier and the content of the secret (even if the content is controlled by an untrusted source).

More information about the new syntax can be found here: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#multline-strings

**Many thanks to @cxhercules for [reporting](https://github.com/secrethub/actions/pull/18) this issue and providing a suggested fix!**