### PR TITLE
Release v0.2.1

### DIFF
--- a/env-export/app-info.sh
+++ b/env-export/app-info.sh
@@ -2,4 +2,4 @@
 
 export SECRETHUB_APP_INFO_NAME=secrethub-action-env-export
 # Version is automatically bumped on release branches
-export SECRETHUB_APP_INFO_VERSION=0.2.0
+export SECRETHUB_APP_INFO_VERSION=0.2.1


### PR DESCRIPTION
## Fixed
- Use new environment files for setting environment variables now that the `::set-env` command is deprecated because of [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w) (https://github.com/secrethub/actions/pull/21)