### PR TITLE
Bump the version used in the readme to v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: secrethub/actions/env-export@v0.1.0
+      - uses: secrethub/actions/env-export@v0.2.1
         env:
           SECRETHUB_CREDENTIAL: ${{ secrets.SECRETHUB_CREDENTIAL }}
           SLACK_WEBHOOK: secrethub://company/app/slack/webhook


### PR DESCRIPTION
`v0.1.0` is no longer supported, as GitHub has now removed support for `::set-env` fully.